### PR TITLE
Include AX_PKG_CHECK_MODULES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,16 +6,18 @@ dist_aclocal_DATA = \
 	autoconf-archive/m4/ax_append_flag.m4				\
 	autoconf-archive/m4/ax_check_compile_flag.m4			\
 	autoconf-archive/m4/ax_is_release.m4				\
+	autoconf-archive/m4/ax_code_coverage.m4				\
 	autoconf-archive/m4/ax_compiler_flags.m4			\
 	autoconf-archive/m4/ax_compiler_flags_cflags.m4			\
 	autoconf-archive/m4/ax_compiler_flags_cxxflags.m4		\
 	autoconf-archive/m4/ax_compiler_flags_ldflags.m4		\
 	autoconf-archive/m4/ax_compiler_flags_gir.m4			\
+	autoconf-archive/m4/ax_pkg_check_modules.m4			\
 	autoconf-archive/m4/ax_require_defined.m4			\
 	$(NULL)
 
 all-local: $(dist_aclocal_DATA)
-	cat $^ | grep -v '^#' | sed -e 's/\<dnl\>.*//' | grep -o '\<AX_[A-Z0-9_]*[A-Z0-9]\>' | sort | uniq > used
+	cat $^ | grep -v '^#' | grep -v 'AX_PACKAGE_REQUIRES' | sed -e 's/\<dnl\>.*//' | grep -o '\<AX_[A-Z0-9_]*[A-Z0-9]\>' | sort | uniq > used
 	cat $^ | grep ^AC_DEFUN | grep -o '\<AX_[A-Z0-9_]*\>' | sort | uniq > defined
 	diff -u used defined
 	rm -f used defined


### PR DESCRIPTION
AX_PKG_CHECK_MODULES is required by gtksourceview. We could copy it into gtksourceview's git repository, but it seems nicer to add it here since it will probably be useful for other modules as well.

Warning: I didn't actually test this -- GitHub web interface promotes laziness!

@swilmet