### PR TITLE
Add AX_CXX_COMPILE_STDCXX_11 macro

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ dist_aclocal_DATA = \
 	autoconf-archive/m4/ax_compiler_flags_cxxflags.m4		\
 	autoconf-archive/m4/ax_compiler_flags_ldflags.m4		\
 	autoconf-archive/m4/ax_compiler_flags_gir.m4			\
+	autoconf-archive/m4/ax_cxx_compile_stdcxx_11.m4			\
 	autoconf-archive/m4/ax_pkg_check_modules.m4			\
 	autoconf-archive/m4/ax_require_defined.m4			\
 	$(NULL)


### PR DESCRIPTION
It's needed for building PackageKit in gnome-continuous.